### PR TITLE
Implement lookaround to return relations with noter tags around a given footprint

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
     environment:
       DJANGO_SETTINGS_MODULE: noter_backend.dev_settings
       DATABASE_URL: 'postgres://noter-backend:noter-backend@db:5432'
+      NOTER_DB_NAME: 'noter'
       NOTER_DB_HOST: 'db'
       NOTER_GS_PROJECT_ID: ''
       # If NOTER_GS_MEDIA_BUCKET_NAME is empty, local disk will be used.
@@ -23,7 +24,7 @@ services:
       NOTER_GS_MEDIA_BUCKET_NAME: ''
       GOOGLE_APPLICATION_CREDENTIALS: '/etc/google_cloud.json'
       NOTER_LOOKUP_ENDPOINTS_YAML: 'etc/lookup_endpoints.yaml'
-
+      KARTTA_EDITOR_URL: 'https://re.city/e'
     build:
       context: .
       dockerfile: Dockerfile

--- a/etc/lookup_endpoints.example.yaml
+++ b/etc/lookup_endpoints.example.yaml
@@ -1,3 +1,4 @@
 endpoints:
+  - 'http://0.0.0.0:3001/api/v0.1/lookaround'
   - 'https://a-url/a-prefix'
   - 'https://another-url/another-prefix'

--- a/noter_backend/looker/views.py
+++ b/noter_backend/looker/views.py
@@ -18,6 +18,7 @@ from noter_backend.settings import lookup_endpoints
 
 from django.shortcuts import render
 import os
+import json
 from django.http import Http404
 import requests
 
@@ -49,8 +50,68 @@ class LookUp(APIView):
       records = requests.get(endpoint, params=payload)
       if records.status_code == status.HTTP_200_OK:
         try:
-          response.data['candidates'].append({'from':endpoint ,'urls':records.json()['data']})
-        except:
+          response.data['candidates'].append({'from':endpoint , 'items':records.json()['data']})
+        except Exception as e:
           pass
     response['Content-Type'] = 'application/json'
+    return response
+
+class LookAround(APIView):
+  def get_bbox(self, coordinates):
+    bbox = {'lonMin':180, 'lonMax':-180, 'latMin':90, 'latMax':-90}
+    lon = 0; lon_min = 180; lon_max = -180
+    lat = 0; lat_min = 90; lat_max = -90
+    for coordinate in coordinates:
+      lon = coordinate[0]
+      lat = coordinate[1]
+
+      lon_min = lon_min if lon_min < lon else lon
+      lon_max = lon_max if lon_max > lon else lon
+      lat_min = lat_min if lat_min < lat else lat
+      lat_max = lat_max if lat_max > lat else lat
+
+    # TODO(sasantv): A better approach is to expand the bbox in meters.
+    EXPANSION_IN_DEGREES = 0.001
+    lon_min -= EXPANSION_IN_DEGREES
+    lon_max += EXPANSION_IN_DEGREES
+    lat_min -= EXPANSION_IN_DEGREES
+    lat_max += EXPANSION_IN_DEGREES
+    return ','.join(str(x) for x in [lon_min,lat_min,lon_max,lat_max])
+
+  def fetch_relations_with_noter_tag(self, bbox):
+    headers = {'Accept':'application/json'}
+    payload = {'bbox': bbox}
+    editor_map_endpoint = os.environ.get('KARTTA_EDITOR_URL').strip('/') + '/api/0.6/map'
+    records = requests.get(editor_map_endpoint, params=payload, headers=headers)
+    if records.status_code != status.HTTP_200_OK:
+      return None, records.status_code
+    relations = []
+    records = records.json()
+    for element in records['elements']:
+      if element['type'] == 'relation' and 'noter_image_id' in element['tags']:
+        relations.append(element)
+    return relations, status.HTTP_200_OK
+
+  def get(self, request, format=None):
+    if 'footprint' in request.query_params:
+      footprint = json.loads(request.query_params['footprint'])
+    elif 'footprint' in request.data:
+      footprint = json.loads(request.data['footprint'])
+    else:
+      return Response(status=status.HTTP_400_BAD_REQUEST)
+
+    if ('geometry' not in footprint
+        or 'coordinates' not in footprint['geometry']
+        or len(footprint['geometry']['coordinates']) < 1
+        or len(footprint['geometry']['coordinates'][0]) < 1):
+      return Response(status=status.HTTP_400_BAD_REQUEST)
+
+    bbox = self.get_bbox(footprint['geometry']['coordinates'][0])
+    relations, status_code = self.fetch_relations_with_noter_tag(bbox)
+    if status_code != status.HTTP_200_OK:
+      return Response(status_code)
+    response = Response(status.HTTP_200_OK)
+    response['Content-Type'] = 'application/json'
+    response.data = {'data':[]}
+    response.data['data'].append({"relations":relations})
     return response

--- a/noter_backend/noter_backend/urls.py
+++ b/noter_backend/noter_backend/urls.py
@@ -38,6 +38,7 @@ urlpatterns = [
     path('api/v0.1/whoami/', views.WhoAmI.as_view()),
     path('download/<int:pk>/', views.GetImage.as_view()),
     path('lookup/', looker_views.LookUp.as_view()),
+    path('api/v0.1/lookaround/', looker_views.LookAround.as_view()),
     path('api/v0.1/whatdoihave/', views.WhatDoIHave.as_view()),
     path('admin/', admin.site.urls),
 ]  + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT) + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
This CL adds an endpoint, api/v0.1/lookaround/ that receives a footprint and returns relationships with noter tags around it.
Note that while this endpoint is available for external calls, it is recommended to be called through the lookup/ endpoint. To let users do this, you must add 'http://0.0.0.0:3001/api/v0.1/lookaround' to the secrets/lookup_endpoints.yaml as shown in the example yaml file.